### PR TITLE
chore(elastic-search): add prepare script for firebase installation

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -3,6 +3,7 @@
   "version": "0.3.0",
   "description": "An extension that syncs data from Google's Cloud Firestore to Elastic App Search.",
   "scripts": {
+    "prepare": "npm run build",
     "build": "tsc",
     "watch": "tsc -w",
     "test": "jest",


### PR DESCRIPTION
Firebase extensions will currently fail on installation as the lib files will be unavailable.

Adding the proposed `prepare` script will build the source at runtime and successfully install the extension.