### PR TITLE
fix(elastic-search): added secret type for ext config

### DIFF
--- a/extension.yaml
+++ b/extension.yaml
@@ -78,6 +78,7 @@ params:
 
   - param: APP_SEARCH_API_KEY
     label: Elastic App Search private API key
+    type: secret
     description: >-
       A "private" API key from your Elastic App Search deployment, with access to the specified engine.
       Found in the "Credentials" section.


### PR DESCRIPTION
Upcoming changes will allow a secret type to define secrets and passwords. This adds the type to  the `APP_SEARCH_API_KEY` parameter.